### PR TITLE
Add app uri scheme to app.json to fix linking issue + HTTPS web start command

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,7 @@
 {
   "expo": {
     "name": "koha",
+    "scheme": "koha",
     "slug": "koha",
     "version": "1.0.0",
     "orientation": "portrait",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web",
+    "web": "expo start:web --https",
     "eject": "expo eject"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes error that occurs when logging in as per [Expo linking documentation](https://docs.expo.dev/guides/linking/)
Changed web start command to start with HTTPS by default.